### PR TITLE
Support summing strings as numbers.

### DIFF
--- a/src/util/AggregateOps.js
+++ b/src/util/AggregateOps.js
@@ -29,7 +29,7 @@ export var AggregateOps = {
   'sum': measure({
     name: 'sum',
     init: 'this.sum = 0;',
-    add:  'this.sum += v;',
+    add:  'this.sum += +v;',
     rem:  'this.sum -= v;',
     set:  'this.sum'
   }),


### PR DESCRIPTION
Vega aggregates support strings instead of numbers for all aggregates (as far as I can see) except sum. This is because JavaScript treats `+` as concatenation as soon as one argument is a string (🤦‍♂️). See https://beta.observablehq.com/@domoritz/wtf-js-numbers for examples.

This PR converts strings to numbers for sum aggregates. 